### PR TITLE
fix libev git url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
         ignore = dirty
 [submodule "external/libev"]
 	path = external/libev
-	url = https://git.lighttpd.net/libev.git
+	url = https://git.lighttpd.net/mirrors/libev.git
         ignore = dirty
 [submodule "external/lmdb"]
 	path = external/lmdb


### PR DESCRIPTION
This fixes the submodule url for the libev external dependency.  Prior to this change, `git submodule update --init` was failing for me.